### PR TITLE
Issue5 update api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 -   You can read API docs [here](https://berealapi.fly.dev/api) (some routes are not working on swagger but only in it, yes in fetch, axios, postman...)
 -   Is done by my [BeReal client](https://github.com/chemokita13/NodeBeFakeClient) (but with some changes)
 -   Only I want if you use it, is one star ⭐
--   Contact me for erros or explanation (my email is in my [gh profile](https://github.com/chemokita13)) or also in repo's discussions or iusses
+-   Contact me for errors or explanation (my email is in my [gh profile](https://github.com/chemokita13)) or also in repo's discussions or iusses
 
 ---
 
@@ -55,7 +55,7 @@ npm run build
 npm run start:prod
 ```
 
-And you will have it deployed in localhost:3000
+And you will have it deployed in http://localhost:3000
 
 ---
 

--- a/src/friends/friends.controller.ts
+++ b/src/friends/friends.controller.ts
@@ -70,7 +70,11 @@ export class FriendsController {
         description: 'JWT Token returned in /login/verify route',
         required: true,
     })
-    @ApiOperation({ summary: 'Get your friends-of-friends feed' })
+    @ApiOperation({
+        summary: 'Get your friends-of-friends feed',
+        description:
+            'Only works if the user have posted, if not, the route will return empty json',
+    })
     @ApiResponse({
         description: `Feed generated.`,
         status: 200,

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -1,7 +1,12 @@
 import { Controller } from '@nestjs/common';
 import { LoginService } from './login.service';
 import { Post, Body } from '@nestjs/common';
-import { APIresponse, LoginDto, VerifyDto } from 'src/types/types';
+import {
+    APIresponse,
+    LoginDto,
+    LoginRefreshDto,
+    VerifyDto,
+} from 'src/types/types';
 import {
     ApiBody,
     ApiOperation,
@@ -132,11 +137,9 @@ export class LoginController {
         return this.loginService.verifyCode(body);
     }
 
-    @ApiParam({
-        name: 'token',
-        description: 'JWT Token returned in /login/verify route',
-        type: 'string',
-        example: 'JWT_TOKEN',
+    @ApiBody({
+        description: 'Credentials to authenticate a user',
+        type: LoginRefreshDto,
     })
     @ApiOperation({ summary: 'Refresh token' })
     @ApiResponse({

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -1,7 +1,7 @@
 import { Controller } from '@nestjs/common';
 import { LoginService } from './login.service';
 import { Post, Body } from '@nestjs/common';
-import { APIresponse, LoginDto } from 'src/types/types';
+import { APIresponse, LoginDto, VerifyDto } from 'src/types/types';
 import {
     ApiBody,
     ApiOperation,
@@ -74,17 +74,9 @@ export class LoginController {
         return this.loginService.sendCode(body);
     }
 
-    @ApiParam({
-        name: 'code',
-        description: 'Code to verify',
-        type: 'string',
-        example: '123456',
-    })
-    @ApiParam({
-        name: 'otpSesion',
-        description: 'Otp session returned in send-code endpoint',
-        type: 'string',
-        example: 'exampleexampleexampleexample',
+    @ApiBody({
+        description: 'Credentials to authenticate a user',
+        type: VerifyDto,
     })
     @ApiOperation({ summary: 'Verify otp code' })
     @ApiResponse({

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -1,19 +1,23 @@
 import { Controller } from '@nestjs/common';
 import { LoginService } from './login.service';
 import { Post, Body } from '@nestjs/common';
-import { APIresponse } from 'src/types/types';
-import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { APIresponse, LoginDto } from 'src/types/types';
+import {
+    ApiBody,
+    ApiOperation,
+    ApiParam,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
 
 @ApiTags('Login')
 @Controller('login')
 export class LoginController {
     constructor(private readonly loginService: LoginService) {}
 
-    @ApiParam({
-        name: 'phone',
-        description: 'Phone number to send otp code',
-        type: 'string',
-        example: '+34123456789',
+    @ApiBody({
+        description: 'Credentials to authenticate a user',
+        type: LoginDto,
     })
     @ApiOperation({ summary: 'Send otp code to your phone' })
     @ApiResponse({

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -135,7 +135,7 @@ export class LoginController {
     })
     @Post('/verify')
     VerifyCode(
-        @Body() body: { code: string; otpSesion: string },
+        @Body() body: { code: string; otpSession: string },
     ): Promise<APIresponse> {
         return this.loginService.verifyCode(body);
     }

--- a/src/login/login.service.ts
+++ b/src/login/login.service.ts
@@ -71,13 +71,13 @@ export class LoginService {
 
     public async verifyCode(body: {
         code: string;
-        otpSesion: string;
+        otpSession: string;
     }): Promise<APIresponse> {
         try {
             const bf = new BeFake();
             const response: BeFakeResponse = await bf.verifyOtpCloud(
                 body.code,
-                body.otpSesion,
+                body.otpSession,
             );
 
             if (response.done) {

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -12,7 +12,12 @@ import {
     UseInterceptors,
 } from '@nestjs/common';
 import { PostService } from './post.service';
-import PostDataRequest, { APIresponse, PostData } from 'src/types/types';
+import PostDataRequest, {
+    APIresponse,
+    CommentDto,
+    PostData,
+    deleteCommentDto,
+} from 'src/types/types';
 import {
     FileFieldsInterceptor,
     FileInterceptor,
@@ -111,7 +116,8 @@ export class PostController {
     @ApiOperation({
         summary: 'Create a new post (DEPRECATED, SEE 3 last routes)',
         description:
-            'All params are a formData. NOT WORKING IN SWAGGER (but yes with postman, fetch, axios...)',
+            'All params except a token are a formData. NOT WORKING IN SWAGGER (but yes with postman, fetch, axios...)',
+        deprecated: true,
     })
     @ApiResponse({
         description: `Post created.`,
@@ -244,7 +250,7 @@ export class PostController {
             'application/json': {
                 schema: {
                     example: {
-                        status: 200,
+                        status: 201,
                         message: 'Comment created',
                     },
                 },
@@ -281,17 +287,9 @@ export class PostController {
             },
         },
     })
-    @ApiParam({
-        name: 'postId',
-        description: 'Post id, you can get it in /friends/feed',
-        type: 'string',
-        example: '0btnwqsohhhznB00NEFV2',
-    })
-    @ApiParam({
-        name: 'comment',
-        description: 'Comment content',
-        type: 'string',
-        example: 'Nice post! I like it!',
+    @ApiBody({
+        type: CommentDto,
+        description: 'Comment data and post id',
     })
     @ApiOperation({ summary: 'Comment a post' })
     @Post('/comment')
@@ -309,17 +307,9 @@ export class PostController {
         description: 'JWT Token returned in /login/verify route',
         required: true,
     })
-    @ApiParam({
-        name: 'postId',
-        description: 'Post id, you can get it in /friends/feed',
-        type: 'string',
-        example: '0btnwqsohhhznB00NEFV2',
-    })
-    @ApiParam({
-        name: 'commentId',
-        description: 'Comment id, you can get it in /friends/feed',
-        type: 'string',
-        example: '0btnwqsohhhznB00NEFV2',
+    @ApiBody({
+        type: deleteCommentDto,
+        description: 'Comment data and post id',
     })
     @ApiOperation({ summary: 'Delete a comment' })
     @ApiResponse({

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -15,6 +15,7 @@ import { PostService } from './post.service';
 import PostDataRequest, {
     APIresponse,
     CommentDto,
+    ImageUploadDto,
     PostData,
     deleteCommentDto,
 } from 'src/types/types';
@@ -24,6 +25,7 @@ import {
 } from '@nestjs/platform-express';
 import {
     ApiBody,
+    ApiConsumes,
     ApiExtraModels,
     ApiHeader,
     ApiOperation,
@@ -32,11 +34,11 @@ import {
     ApiTags,
 } from '@nestjs/swagger';
 
+//* WARNING: Fold all to better view (In vscode: cntrl + k + 0)
 @ApiTags('Post')
 @Controller('post')
 export class PostController {
     constructor(private readonly postService: PostService) {}
-    /// I dont know why, but that does not work in swagger api
     @ApiExtraModels(PostData)
     @ApiParam({
         name: 'img1',
@@ -367,10 +369,30 @@ export class PostController {
     }
 
     //* Postupload by steps
+    // TODO: add response ok
     @ApiHeader({
         name: 'token',
         description: 'JWT Token returned in /login/verify route',
         required: true,
+    })
+    @ApiResponse({
+        description: 'Tokens returned',
+        status: 201,
+        content: {
+            'application/json': {
+                schema: {
+                    example: {
+                        status: 201,
+                        message: 'Photo created',
+                        data: {
+                            firstPhotoToken: 'tokentokentokentoken',
+                            secondPhotoToken: 'tokentokentokentoken',
+                            postDataToken: 'tokentokentokentoken',
+                        },
+                    },
+                },
+            },
+        },
     })
     @ApiResponse({
         description: `Token not generated.`,
@@ -404,7 +426,7 @@ export class PostController {
         },
     })
     @ApiOperation({
-        summary: 'Get data to upload a post',
+        summary: 'Get data to upload a post. Step 1 to upload a post',
         description:
             'This route returns 3 tokens, you must send it in /post/upload/data and /post/upload/photo route',
     })
@@ -450,21 +472,14 @@ export class PostController {
         },
     })
     @ApiOperation({
-        summary: 'Upload a photo',
+        summary: 'Upload a photo. Step 2 to upload a post',
         description:
-            'You must send the tokenData returned in /post/upload/getData route (firstPhotoToken or secondPhotoToken)',
+            'You must send the tokenData returned in /post/upload/getData route (firstPhotoToken or secondPhotoToken).',
     })
-    @ApiParam({
-        name: 'tokenData',
-        description: 'Token data returned in /post/upload/getData route',
-        type: 'string',
-        example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
-    })
-    @ApiParam({
-        name: 'img',
-        description: 'Image to upload',
-        type: 'file',
-        required: true,
+    @ApiConsumes('multipart/form-data')
+    @ApiBody({
+        description: 'Image and token to upload',
+        type: ImageUploadDto,
     })
     @UseInterceptors(FileInterceptor('img'))
     @Put('/upload/photo')

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -523,7 +523,7 @@ export class PostController {
         },
     })
     @ApiOperation({
-        summary: 'Upload a post',
+        summary: 'Upload a post. Step 3 to upload a post (last step)',
         description: 'You must send the postData params for your post',
     })
     @ApiBody({

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -28,6 +28,16 @@ export class VerifyDto {
     })
     otpSession: string;
 }
+export class LoginRefreshDto {
+    @ApiProperty({
+        required: true,
+        type: 'string',
+        example: 'exampleexampleexampleexampleexampleexample',
+        description:
+            'This is the refresh token from the /login/verify endpoint',
+    })
+    token: string;
+}
 
 export type APIresponse = {
     status: number;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -28,6 +28,7 @@ export class VerifyDto {
     })
     otpSession: string;
 }
+// Token refresh route dto for swagger (used in login.controller.ts: @ApiBody({ type: LoginRefreshDto })
 export class LoginRefreshDto {
     @ApiProperty({
         required: true,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -82,6 +82,23 @@ export class deleteCommentDto {
     commentId: string;
 }
 
+//* Post upload route types
+// Image upload form dto for swagger (used in post.controller.ts: @ApiBody({ type: ImageUploadDto })
+export class ImageUploadDto {
+    @ApiProperty({
+        required: true,
+        type: 'file',
+        description: 'The image you want to upload',
+    })
+    img: Express.Multer.File;
+    @ApiProperty({
+        required: true,
+        type: 'string',
+        description: 'The token from the /login/verify endpoint',
+    })
+    tokenData: string;
+}
+
 //* Normal API response types
 export type APIresponse = {
     status: number;
@@ -113,9 +130,11 @@ export class PostData {
     late?: boolean;
     @ApiProperty({
         required: true,
-        type: 'friends || friends-of-friends || public',
+        type: 'string',
+        enum: ['friends', 'friends-of-friends', 'public'],
+        example: 'friends || friends-of-friends || public',
     })
-    visibility: string;
+    visibility: 'friends' | 'friends-of-friends' | 'public';
     @ApiProperty({
         required: false,
         default: 0,
@@ -127,12 +146,14 @@ export class PostData {
     caption?: string;
     @ApiProperty({
         required: false,
-        type: 'YYYY-MM-DDTHH:mm:ss.SSS[Z]',
+        type: 'string',
+        example: 'YYYY-MM-DDTHH:mm:ss.SSS[Z]',
     })
     taken_at?: string;
     @ApiProperty({
         required: false,
-        type: '[number(lat), number(lon)]',
+        type: 'string',
+        example: '[number(lat), number(lon)]',
     })
     location?: [number, number];
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -16,12 +16,15 @@ export class VerifyDto {
         required: true,
         type: 'string',
         example: '123456',
+        description: 'This is the code sent to your phone',
     })
     code: string;
     @ApiProperty({
         required: true,
         type: 'string',
         example: 'exampleexampleexampleexampleexampleexample',
+        description:
+            'This is the otpSession from the /login/send-code endpoint',
     })
     otpSession: string;
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -40,6 +40,49 @@ export class LoginRefreshDto {
     token: string;
 }
 
+//* Post module types
+// Coment type
+export class CommentDto {
+    @ApiProperty({
+        title: 'Post id',
+        type: 'string',
+        required: true,
+        description:
+            'The id of the post you want to comment on. Returned on /friends/feed endpoint',
+        example: 'exampleexampleexampleexampleexampleexample',
+    })
+    postId: string;
+    @ApiProperty({
+        title: 'Comment',
+        description: 'The comment you want to post',
+        type: 'string',
+        required: true,
+        example: 'exampleexampleexampleexampleexampleexample',
+    })
+    comment: string;
+}
+export class deleteCommentDto {
+    @ApiProperty({
+        title: 'Post id',
+        type: 'string',
+        required: true,
+        description:
+            'The id of the post you want to delete a comment from. Returned on /friends/feed endpoint',
+        example: 'exampleexampleexampleexampleexampleexample',
+    })
+    postId: string;
+    @ApiProperty({
+        title: 'Comment id',
+        type: 'string',
+        required: true,
+        description:
+            'The id of the comment you want to delete. Returned on /friends/feed endpoint',
+        example: 'exampleexampleexampleexampleexampleexample',
+    })
+    commentId: string;
+}
+
+//* Normal API response types
 export type APIresponse = {
     status: number;
     message: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+// Login dto for swagger (used in login.controller.ts: @ApiBody({ type: LoginDto })
+export class LoginDto {
+    @ApiProperty({
+        required: true,
+        type: 'string',
+        example: '+00123456789',
+    })
+    phone: string;
+}
+
 export type APIresponse = {
     status: number;
     message: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+//* Login types
 // Login dto for swagger (used in login.controller.ts: @ApiBody({ type: LoginDto })
 export class LoginDto {
     @ApiProperty({
@@ -8,6 +9,21 @@ export class LoginDto {
         example: '+00123456789',
     })
     phone: string;
+}
+// Verify dto for swagger (used in login.controller.ts: @ApiBody({ type: VerifyDto })
+export class VerifyDto {
+    @ApiProperty({
+        required: true,
+        type: 'string',
+        example: '123456',
+    })
+    code: string;
+    @ApiProperty({
+        required: true,
+        type: 'string',
+        example: 'exampleexampleexampleexampleexampleexample',
+    })
+    otpSession: string;
 }
 
 export type APIresponse = {


### PR DESCRIPTION
# API Docs updated and "repaired".
The issue was because I wrote the body params as a normaly route params and the devs that are using that API  were confused.
## Big changes
- _"otpSesion"_ param has renamed to **"otpSession"** (with two 's':''ss') in */login/verify* route

## Issue solved
#5 