### PR TITLE
add jwt token header to `/upload/data` doc

### DIFF
--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -536,6 +536,11 @@ export class PostController {
         type: PostDataRequest,
         description: 'Post data and token',
     })
+    @ApiHeader({
+        name: 'token',
+        description: 'JWT Token returned in /login/verify route',
+        required: true,
+    })
     @Post('/upload/data')
     postUpload(
         @Req() req: any,


### PR DESCRIPTION
wanted to make it clear in documentation that the jwt token is required as header